### PR TITLE
Find all applicable RUSTSEC advisories in `security_audit` job

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,6 +35,10 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-audit
+    - name: Open tmate session
+      uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: true
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -43,7 +43,9 @@ jobs:
         cat >cargo <<'EOF'
         #!/bin/sh
         set -eu
-        case "$1" in  # Non-robustly assume subcommand, not option - OK for actions-rs/audit-check.
+        # Assume the first argument is the subcommand, rather than an option. This is not robust,
+        # but it works for the very simple call in actions-rs/audit-check, which is what matters.
+        case "$1" in
         generate-lockfile)
           printf '::warning SKIPPING: %s %s\n' "$0" "$*" ;;
         *)
@@ -52,10 +54,6 @@ jobs:
         EOF
 
         chmod +x cargo
-    # - name: Open tmate session
-    #   uses: mxschmitt/action-tmate@v3
-    #   with:
-    #     limit-access-to-actor: true
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,12 +35,27 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-audit
+    - name: Stub out `cargo generate-lockfile` to work around actions-rs/audit-check#163
+      run: |
+        cd ~/.cargo/bin
+        mv cargo cargo.orig
+
+        cat >cargo <<'EOF'
+        #!/bin/sh
+        set -eu
+        case "$1" in  # Non-robustly assume subcommand, not option - OK for actions-rs/audit-check.
+        generate-lockfile)
+          printf '::warning SKIPPING: %s %s\n' "$0" "$*" ;;
+        *)
+          exec "$0.orig" "$@" ;;
+        esac
+        EOF
+
+        chmod +x cargo
     # - name: Open tmate session
     #   uses: mxschmitt/action-tmate@v3
     #   with:
     #     limit-access-to-actor: true
-    - name: 'Work around https://github.com/actions-rs/audit-check/issues/163'
-      run: chmod -w Cargo.lock
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,10 +35,12 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-audit
-    - name: Open tmate session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: true
+    # - name: Open tmate session
+    #   uses: mxschmitt/action-tmate@v3
+    #   with:
+    #     limit-access-to-actor: true
+    - name: 'Work around https://github.com/actions-rs/audit-check/issues/163'
+      run: chmod -w Cargo.lock
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This works around a bug in the `actions-rs/cargo-check` action, https://github.com/actions-rs/audit-check/issues/163, where it runs `cargo generate-lockfile` even if a fully usable `Cargo.lock` is already present, before running `cargo audit`, thus missing any advisories that affect locked dependency versions but not the latest usable versions that updating `Cargo.lock` would change to.

The action runs `cargo generate-lockfile` and cannot be configured not to do so without modifying the action code itself. It also checks that command's exit status, failing fast if it failed (otherwise `chmod -w Cargo.lock` or `sudo chattr +i Cargo.lock` could be workable solutions). Fortunately, because we are only running this on GitHub-hosted runners, which regenerate the whole virtual machine each time, it is okay to modify the behavior of `cargo` itself.

This renames the `cargo` binary to `cargo.orig` and replaces it with a wrapper script named `cargo` that treats `generate-lockfile` as a special case and does nothing other than display a warning that it is not running the command. Otherwise it hands off to `cargo.orig`, such as to let `cargo audit` itself run in full.

Neither the general approach of wrapping `cargo` to stub out `generate-lockfile`, nor the specific details of how that is achieved here, are implemented here in a fully general way. The approach here is not sufficiently robust for general use, but it should be more than good enough until the use of the unmaintained `actions-rs/cargo-check` action is eventually replaced with some other way to report advisories in an easy-to-read manner.

The squashed history of a few commits, which led to this approach, are shown below. For their full details, see EliahKagan#4.